### PR TITLE
Failure when using with WebRTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+
+.idea/
+yarn.lock

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
     <title>Instascan &ndash; Demo</title>
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="stylesheet" href="style.css">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/3.3.3/adapter.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.10/vue.min.js"></script>
     <script type="text/javascript" src="https://rawgit.com/schmich/instascan-builds/master/instascan.min.js"></script>
   </head>

--- a/src/camera.js
+++ b/src/camera.js
@@ -35,7 +35,7 @@ class Camera {
       return await navigator.mediaDevices.getUserMedia(constraints);
     });
 
-    return window.URL.createObjectURL(this._stream);
+    return this._stream;
   }
 
   stop() {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -289,7 +289,7 @@ class Scanner extends EventEmitter {
     }
 
     let streamUrl = await this._camera.start();
-    this.video.src = streamUrl;
+    this.video.srcObject = streamUrl;
 
     if (this._continuous) {
       this._scanner.start();


### PR DESCRIPTION
Removed usage of window.URL.createObjectURL(...) in favour of returning stream directly. This has been done, since createObjectURL has been deprecated (and using it breaks WebRTC functionality when using webrtc-adapter).

![image](https://cloud.githubusercontent.com/assets/44014/25335138/f9d8864e-28f1-11e7-83b5-72e35e174aa8.png)
