### PR TITLE
Fix for https://github.com/schmich/instascan/issues/47

### DIFF
--- a/export.js
+++ b/export.js
@@ -1,1 +1,4 @@
+require('babel-polyfill');
+require('webrtc-adapter');
+
 window.Instascan = require('./index');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-require('babel-polyfill');
-require('webrtc-adapter');
-
 var Instascan = {
   Scanner: require('./src/scanner'),
   Camera: require('./src/camera')

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "babel-polyfill": "^6.9.1",
     "fsm-as-promised": "^0.13.0",
-    "visibilityjs": "^1.2.3",
+    "visibilityjs": "^1.2.3"
+  },
+  "peerDependencies": {
+    "babel-polyfill": "^6.9.1",
     "webrtc-adapter": "^1.4.0"
   }
 }


### PR DESCRIPTION
Now able to import instascan using a module importer (from node_modules) without depending upon shims. Dists are still build with these bundled.