### PR TITLE
Upgrade webrtc adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "babel-polyfill": "^6.9.1",
     "fsm-as-promised": "^0.13.0",
     "visibilityjs": "^1.2.3",
-    "webrtc-adapter": "^1.4.0"
+    "webrtc-adapter": "^4.1.0"
   }
 }

--- a/src/camera.js
+++ b/src/camera.js
@@ -51,8 +51,6 @@ class Camera {
   }
 
   static async getCameras() {
-    await this._ensureAccess();
-
     let devices = await navigator.mediaDevices.enumerateDevices();
     return devices
       .filter(d => d.kind === 'videoinput')


### PR DESCRIPTION
The adapter was quite some versions behind. The newer version also supports Safari (though it is still buggy). With the newer adapter version, we were receiving the permissions prompt multiple times due to the `ensureAccess` call.

p.s. great lib.