### PR TITLE
Allow users to pass constraints to getUserMedia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ let opts = {
 - If `opts.video` element was specified, it will have the `inactive` CSS class.
 - `callback`: `function ()`
 
-### Instascan.Camera.getCameras()
+### Instascan.Camera.getCameras(options)
 
+- Passes `options` along to getUserMedia ([see available options](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Parameters)).
+  - Defaults to `{ video: { facingMode: 'environment' } }` which will prefer the rear-facing camera if available.
 - Enumerate available video devices. Returns promise.
 - `.then(function (cameras) { ... })`
   - Called when cameras are available.

--- a/README.md
+++ b/README.md
@@ -161,9 +161,7 @@ let opts = {
 
 ## Compatibility
 
-Instascan works on non-iOS platforms in [any browser that supports the WebRTC/getUserMedia API](http://caniuse.com/#feat=stream), which currently includes Chome, Firefox, Opera, and Edge. IE and Safari are not supported.
-
-Instascan does not work on iOS since Apple does not yet support WebRTC in WebKit *and* forces other browser vendors (Chrome, Firefox, Opera) to use their implementation of WebKit. [Apple is actively working on WebRTC support in WebKit](https://bugs.webkit.org/show_bug.cgi?id=124288).
+Instascan works in [any browser that supports the WebRTC/getUserMedia API](http://caniuse.com/#feat=stream), which currently includes Chrome, Safari, Firefox, Opera, and Edge. IE is not supported.
 
 ## Performance
 

--- a/src/camera.js
+++ b/src/camera.js
@@ -50,8 +50,10 @@ class Camera {
     this._stream = null;
   }
 
-  static async getCameras() {
-    await this._ensureAccess();
+  static async getCameras(options) {
+    let defaults = { video: { facingMode: 'environment' } };
+    let constraints = Object.assign({}, defaults, options);
+    await this._ensureAccess(constraints);
 
     let devices = await navigator.mediaDevices.enumerateDevices();
     return devices
@@ -59,9 +61,9 @@ class Camera {
       .map(d => new Camera(d.deviceId, cameraName(d.label)));
   }
 
-  static async _ensureAccess() {
+  static async _ensureAccess(constraints) {
     return await this._wrapErrors(async () => {
-      let access = await navigator.mediaDevices.getUserMedia({ video: true });
+      let access = await navigator.mediaDevices.getUserMedia(constraints);
       for (let stream of access.getVideoTracks()) {
         stream.stop();
       }


### PR DESCRIPTION
This PR lets users optionally pass parameters to `getCameras`, which will pass them on to the native `getUserMedia`. It also changes the default to prefer, but not require, a rear-facing camera.

Should take care of #33 and #41.