### PR TITLE
update to es2015 syntax to work around webpack2 issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ require('babel-polyfill');
 require('webrtc-adapter');
 
 var Instascan = {
-  Scanner: require('./src/scanner'),
-  Camera: require('./src/camera')
+  Scanner: require('./src/scanner').default,
+  Camera: require('./src/camera').default
 };
 
 module.exports = Instascan;

--- a/src/camera.js
+++ b/src/camera.js
@@ -81,4 +81,4 @@ class Camera {
   }
 }
 
-module.exports = Camera;
+export default Camera;

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -370,4 +370,4 @@ class Scanner extends EventEmitter {
   }
 }
 
-module.exports = Scanner;
+export default Scanner;


### PR DESCRIPTION
I'm not sure if this is a good change, but this change workaround the below webpack2 issue

update to es2015 syntax to work around webpack2 issue https://github.com/webpack/webpack/issues/4039

although the library might break in node.js that don't support ES2015 syntax
