### PR TITLE
Remove autoplay value, fixing compatibility with Safari macOS and iOS 11

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -316,7 +316,7 @@ class Scanner extends EventEmitter {
     }
 
     let video = opts.video || document.createElement('video');
-    video.setAttribute('autoplay', 'autoplay');
+    video.setAttribute('autoplay', '');
 
     return video;
   }

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -316,7 +316,6 @@ class Scanner extends EventEmitter {
     }
 
     let video = opts.video || document.createElement('video');
-    video.setAttribute('autoplay', '');
 
     return video;
   }


### PR DESCRIPTION
Autoplay is a boolean attribute, and Safari (both macOS and iOS 11 Safari) appears to choke if it is given a value.

[The spec states](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#Example), counter-intuitively, that passing an _empty string_ as the `value` is the proper way to to define a boolean attribute as `true`:

> Boolean attributes are considered to be true if they're present on the element at all, regardless of their actual value; as a rule, you should specify the empty string (`””`) in `value` (some people use the attribute's name; this works but is non-standard).