### PR TITLE
Correctly select camera when starting scanner

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -21,13 +21,9 @@ class Camera {
     let constraints = {
       audio: false,
       video: {
-        mandatory: {
-          sourceId: this.id,
-          minWidth: 600,
-          maxWidth: 800,
-          minAspectRatio: 1.6
-        },
-        optional: []
+        deviceId: { 
+          exact: this.id 
+        }
       }
     };
 


### PR DESCRIPTION
This change correctly selects the camera when there is more than one camera available.