### PR TITLE
Avoid asking for permissions twice

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -50,8 +50,10 @@ class Camera {
     this._stream = null;
   }
 
-  static async getCameras() {
-    await this._ensureAccess();
+  static async getCameras(ensureAccess = false) {
+    if (ensureAccess) {
+      await this._ensureAccess();
+    }
 
     let devices = await navigator.mediaDevices.enumerateDevices();
     return devices


### PR DESCRIPTION
See https://github.com/schmich/instascan/issues/110

No permission asked during getCameras(), option to skip _ensureAccess().